### PR TITLE
Get element by id

### DIFF
--- a/src/menuspy.js
+++ b/src/menuspy.js
@@ -43,7 +43,7 @@ class MenuSpy {
 
   cacheItems() {
     this.scrollItems = this.menuItems.map((a) => {
-      const elm = document.querySelector(a.getAttribute('href'));
+      const elm = document.getElementById(a.getAttribute('href').slice(1));
       if (elm) {
         const offset = utils.offset(elm).top;
         return { elm, offset };


### PR DESCRIPTION
I have the following in my HTML

```html
<a href="#Maybe<A>">Maybe<A></a>
```

It works perfectly fine. However, MenuSpy tries to use the string `"#Maybe<A>"` as a selector. This gives the following error:

```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#Maybe<A>' is not a valid selector.
```

This PR fixes the issue by not using the `href` attribute directly as a query selector but instead stripping the leading `#` from it and looking for an element with that id.